### PR TITLE
Remove _has_session

### DIFF
--- a/app.wsgi
+++ b/app.wsgi
@@ -202,7 +202,7 @@ def _create_session(username):
     expire_time = 5*60*60
     redis.setex(session_id, username, expire_time)
     response.set_cookie('session_id', session_id, expires=expire_time, path='/')
-    requiest.environ["__current_session"] = username
+    request.environ["__current_session"] = username
     return session_id
 
 


### PR DESCRIPTION
getting the session after checking for _has_session is wasteful,
because this forces the client to make at least two calls to the
backend dataastore

  EXISTS ...
  GET ...

The network latency is much higher than reading a few extra bytes
in recent machines