### PR TITLE
Add a news page, linking blog articles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jinja2
 redis
 wsgi-request-logger
 py-gfm
+feedparser

--- a/views/news.tpl
+++ b/views/news.tpl
@@ -1,0 +1,27 @@
+{% extends 'base.tpl' %}
+
+{% block heroimage %}{% endblock %}
+
+{% block main %}
+<main>
+  <div class="section article">
+    <div class="inner">
+      <h1 class="section-header">Recent News</h1>
+      <div class="section-content">
+        <div class="post-content">
+          <ul class="post-list">
+          {% for entry in entries %}
+            <li>
+              <span class="post-meta">{{ entry.date }}</span>
+              <h2>
+                <a class="post-link" href="{{ entry.link }}">{{ entry.title }}</a>
+              </h2>
+            </li>
+          {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>
+{% endblock %}


### PR DESCRIPTION
* [Screenshot mobile](http://res.cloudinary.com/dlze0abrr/image/upload/v1469280954/image1_rxujiq.png)
* [Screenshot PC](http://res.cloudinary.com/dlze0abrr/image/upload/v1469280685/2016-07-23_22h30_59_m7u3sc.png)


まずはトップページの、つまりbuilderscon全体のニュース。
後からカンファレンスごとのニュースは作成します。

>lestrrat [8:15 AM] 
>a)で、カテゴリをblog.buildersconでそれぞれ切って、それのみのRSSかなんかを定期的に読み込むというのはどうか