### PR TITLE
Fix issue for overlapping nav bar and contents #29

### DIFF
--- a/assets/css/html.css
+++ b/assets/css/html.css
@@ -243,12 +243,21 @@ a.disabled	{ color: #555; }
   - HERO IMAGE
 ----------------------------------------------------------*/
 
+#heroimage-empty {
+	position: relative;
+	width: 100%;
+}
 #heroimage {
 	position: relative;
 	width: 100%;
 }
 
+
 @media screen and (min-width: 900px) and (max-width: 931931px) {
+	#heroimage-empty {
+		position: relative;
+		height: 110px;
+	}
 	#heroimage {
 		position: relative;
 		height: 410px;
@@ -314,6 +323,10 @@ a.disabled	{ color: #555; }
 }
 
 @media screen and (min-width: 0px) and (max-width: 899px) {
+	#heroimage-empty {
+		position: relative;
+		height: auto;
+	}
 	#heroimage {
 		position: relative;
 		height: auto;

--- a/views/news.tpl
+++ b/views/news.tpl
@@ -1,6 +1,8 @@
 {% extends 'layout/conference.tpl' %}
 
-{% block heroimage %}{% endblock %}
+{% block heroimage %}
+<div id="heroimage-empty"></div>
+{% endblock %}
 
 {% block main %}
 <main>

--- a/views/sponsors.tpl
+++ b/views/sponsors.tpl
@@ -1,6 +1,8 @@
 {% extends 'layout/conference.tpl' %}
 
-{% block heroimage %}{% endblock %}
+{% block heroimage %}
+<div id="heroimage-empty"></div>
+{% endblock %}
 
 {% block main %}
 <style type="text/css">


### PR DESCRIPTION
Refs #29 

Media Queryはwidth=900pxを境に、この二つしかないので、スクリーンショットも二つだけ貼っておきます。

大きいサイズも小さいサイズもうまくいっています→navバーと、コンテンツが重なっていません。

html.css

>[@media screen and (min-width: 0px) and (max-width: 899px) {](https://github.com/builderscon/conf.builderscon.io/blob/master/assets/css/html.css#L107)


>[@media screen and (min-width: 900px) and (max-width: 931931px) {](https://github.com/builderscon/conf.builderscon.io/blob/master/assets/css/html.css#L165)



![image](https://cloud.githubusercontent.com/assets/7414320/17145502/52d257e4-5395-11e6-824a-03dd81e1af0d.png)

![image](https://cloud.githubusercontent.com/assets/7414320/17145518/62e3a480-5395-11e6-8d8c-f3fb71d45a88.png)
