### PR TITLE
Add session details (phase 1)

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -49,7 +49,14 @@ div.tier-3 div.sponsor-name {
     font-size: 60%;
 }
 
-.social-button {
+div.social-button {
+    margin: 10px 0px;
     display: inline-block;
     vertical-align: top;
+}
+
+@media screen and (min-width: 64em) {
+    div.social-button {
+        display: block;
+    }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -49,3 +49,7 @@ div.tier-3 div.sponsor-name {
     font-size: 60%;
 }
 
+.social-button {
+    display: inline-block;
+    vertical-align: top;
+}

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -33,7 +33,7 @@
         <div class="row">
           <div class="small-12 columns">
             <p>
-              {{session.abstract}}
+              {{session.abstract | markdown}}
             </p>
           </div>
         </div>

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -9,11 +9,11 @@
       <div class="section-content">
 
         <div class="row">
-          <div class="text-center small-4 large-2 columns">
+          <div class="text-center large-2 columns">
             <img style="width: 120px; height: 120px; border: 1px solid #ccc" src="{% if session.speaker.avatar_url %}{{ session.speaker.avatar_url }}{% else %}{{ url('static', filename='images/noprofile.png') }}{% endif %}" />
-            <div class="text-center"><a  href="." target="_blank">{{session.speaker.nickname}}</a></div>
-          </div>
-          <div class="small-8 large-10 columns">
+            <div class="text-center">
+              <a  href="." target="_blank">{{session.speaker.nickname}}</a>
+            </div>
             <div class="social-button">
               <a href="http://b.hatena.ne.jp/entry/" class="hatena-bookmark-button" data-hatena-bookmark-layout="vertical-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
             </div>
@@ -26,12 +26,11 @@
             <div class="social-button">
               <a href="https://twitter.com/share" class="twitter-share-button" data-size="large">Tweet</a>
             </div>
+
+            <!-- add new buttons here e.g. edit session details button -->
+
           </div>
-        </div>
-
-
-        <div class="row">
-          <div class="small-12 columns">
+          <div class="large-10 columns">
             <p>
               {{session.abstract | markdown}}
             </p>

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -59,20 +59,6 @@
           </table>
         </div>
 
-{% if session.video_embed_html %}
-        <div class="row text-center">
-          <div class="small-12 columns">
-            {{session.video_embed_html}}
-          </div>
-        </div>
-{% endif %}
-
-{% if session.slide_embed_html  %}
-        <div class="row text-center">
-          {{session.slide_embed_html}}
-        </div>
-{% endif %}
-
       </div>
     </div>
   </div>

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -7,14 +7,12 @@
       <h1 class="section-header">{{session.title}}</h1>
       <div class="section-content">
 
-{% if session.session_type %}
         <div class="row">
           <div class="small-6 large-2 columns">
             <img style="width: 120px; height: 120px; border: 1px solid #ccc" src="{% if session.speaker.avatar_url %}{{ session.speaker.avatar_url }}{% else %}{{ url('static', filename='images/noprofile.png') }}{% endif %}" />
             <div class="text-center"><a  href="." target="_blank">{{session.speaker.nickname}}</a></div>
           </div>
         </div>
-{% endif %}
 
         <div class="row">
           <div class="small-12 columns">
@@ -34,12 +32,10 @@
               <td>Starts On</td>
               <td>{{session.starts_on}}</td>
             </tr>
-{% if session.session_type %}
             <tr>
               <td>Duration</td>
               <td>{{session.session_type.name}}</td>
             </tr>
-{% endif %}
             <tr>
               <td>Spoken Language</td>
               <td>{{session.spoken_language}}</td>

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -28,10 +28,12 @@
               <td>Material Level</td>
               <td>{{session.material_level}}</td>
             </tr>
+{% if session.starts_on %}
             <tr>
               <td>Starts On</td>
               <td>{{session.starts_on}}</td>
             </tr>
+{% endif %}
             <tr>
               <td>Duration</td>
               <td>{{session.session_type.name}}</td>

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -1,6 +1,7 @@
 {% extends 'layout/base.tpl' %}
 
 {% block main %}
+<div id="fb-root"></div>
 <main>
   <div class="section article">
     <div class="inner">
@@ -8,11 +9,26 @@
       <div class="section-content">
 
         <div class="row">
-          <div class="small-6 large-2 columns">
+          <div class="text-center small-4 large-2 columns">
             <img style="width: 120px; height: 120px; border: 1px solid #ccc" src="{% if session.speaker.avatar_url %}{{ session.speaker.avatar_url }}{% else %}{{ url('static', filename='images/noprofile.png') }}{% endif %}" />
             <div class="text-center"><a  href="." target="_blank">{{session.speaker.nickname}}</a></div>
           </div>
+          <div class="small-8 large-10 columns">
+            <div class="social-button">
+              <a href="http://b.hatena.ne.jp/entry/" class="hatena-bookmark-button" data-hatena-bookmark-layout="vertical-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
+            </div>
+            <div class="social-button">
+              <div class="g-plusone" data-size="tall"  data-href="{{request.path}}"></div>
+            </div>
+            <div class="social-button">
+              <div class="fb-like" data-href="{{request.path}}" data-layout="box_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
+            </div>
+            <div class="social-button">
+              <a href="https://twitter.com/share" class="twitter-share-button" data-size="large">Tweet</a>
+            </div>
+          </div>
         </div>
+
 
         <div class="row">
           <div class="small-12 columns">
@@ -62,3 +78,16 @@
   </div>
 </main>
 {% endblock%}
+
+{% block scripts %}
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<script>(function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0];
+  if (d.getElementById(id)) return;
+  js = d.createElement(s); js.id = id;
+  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.7";
+  fjs.parentNode.insertBefore(js, fjs);
+}(document, 'script', 'facebook-jssdk'));</script>
+</script>
+<script src="https://apis.google.com/js/platform.js" async defer></script>
+{% endblock %}

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -3,9 +3,78 @@
 {% block main %}
 <main>
   <div class="section article">
-    <div class="inner"></div>
-    <div class="section-header">{{ session.title }}</div>
-    <div class="section-content"></div>
+    <div class="inner">
+      <h1 class="section-header">{{session.title}}</h1>
+      <div class="section-content">
+
+{% if session.session_type %}
+        <div class="row">
+          <div class="small-6 large-2 columns">
+            <img style="width: 120px; height: 120px; border: 1px solid #ccc" src="{% if session.speaker.avatar_url %}{{ session.speaker.avatar_url }}{% else %}{{ url('static', filename='images/noprofile.png') }}{% endif %}" />
+            <div class="text-center"><a  href="." target="_blank">{{session.speaker.nickname}}</a></div>
+          </div>
+        </div>
+{% endif %}
+
+        <div class="row">
+          <div class="small-12 columns">
+            <p>
+              {{session.abstract}}
+            </p>
+          </div>
+        </div>
+
+        <div class="row">
+          <table>
+            <tr>
+              <td>Material Level</td>
+              <td>{{session.material_level}}</td>
+            </tr>
+            <tr>
+              <td>Starts On</td>
+              <td>{{session.starts_on}}</td>
+            </tr>
+{% if session.session_type %}
+            <tr>
+              <td>Duration</td>
+              <td>{{session.session_type.name}}</td>
+            </tr>
+{% endif %}
+            <tr>
+              <td>Spoken Language</td>
+              <td>{{session.spoken_language}}</td>
+            </tr>
+            <tr>
+              <td>Slide Language</td>
+              <td>{{session.slide_language}}</td>
+            </tr>
+            <tr>
+              <td>May we take your photo?</td>
+              <td>{{session.photo_permission}}</td>
+            </tr>
+            <tr>
+              <td>May we record your session?</td>
+              <td>{{session.video_permission}}</td>
+            </tr>
+          </table>
+        </div>
+
+{% if session.video_embed_html %}
+        <div class="row text-center">
+          <div class="small-12 columns">
+            {{session.video_embed_html}}
+          </div>
+        </div>
+{% endif %}
+
+{% if session.slide_embed_html  %}
+        <div class="row text-center">
+          {{session.slide_embed_html}}
+        </div>
+{% endif %}
+
+      </div>
+    </div>
   </div>
 </main>
 {% endblock%}

--- a/templates/session_detail.tpl
+++ b/templates/session_detail.tpl
@@ -18,10 +18,10 @@
               <a href="http://b.hatena.ne.jp/entry/" class="hatena-bookmark-button" data-hatena-bookmark-layout="vertical-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script>
             </div>
             <div class="social-button">
-              <div class="g-plusone" data-size="tall"  data-href="{{request.path}}"></div>
+              <div class="g-plusone" data-size="tall"  data-href="{{url}}"></div>
             </div>
             <div class="social-button">
-              <div class="fb-like" data-href="{{request.path}}" data-layout="box_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
+              <div class="fb-like" data-href="{{url}}" data-layout="box_count" data-action="like" data-size="large" data-show-faces="false" data-share="false"></div>
             </div>
             <div class="social-button">
               <a href="https://twitter.com/share" class="twitter-share-button" data-size="large">Tweet</a>


### PR DESCRIPTION
Refs #43 

まだ全て終わったわけではありませんが、一旦ready for reviewのつもりです。大まかなレイアウトを中心に見ていただいて、ツッコミを頂けるとありがたいです。[YAPC 2015のレイアウト](http://yapcasia.org/2015/talk/show/621948f2-0d46-11e5-a403-67dc7d574c3a)を参考にしました。

![image](https://cloud.githubusercontent.com/assets/7414320/17793784/f082f94c-65e4-11e6-9056-131bbbbc12e0.png)
![image](https://cloud.githubusercontent.com/assets/7414320/17793785/f532f672-65e4-11e6-9a55-08c33294c04a.png)


## 次回以降のPRでやること(一個のPRで全部やるとごちゃごちゃすると思いますので…)

 - 顔写真の横の空間を埋める
![image](https://cloud.githubusercontent.com/assets/7414320/17793823/3ed276fe-65e5-11e6-9a77-997c86e6a21c.png)

- oEmbed対応
  - permalinkをoEmbed APIに渡す→[responseの中にあるiframe](https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=w-V8tyz9SAs)をsession_details.tplに渡す
  - responsive対応 -> 画面サイズに合わせてoEmbed APIにmaxwidthパラメタを渡して呼び出す
- 人間が読みづらい値を読みやすい値に変換する
 - spoken, slide language の "en" -> "English"
 - start on = 0001-01-01T00:00:00Z -> 人間が読める時刻表示
 - Pythonのどこかに変換する関数(?)を定義