### PR TITLE
Show session abstract in session list

### DIFF
--- a/templates/sessions.tpl
+++ b/templates/sessions.tpl
@@ -77,6 +77,7 @@ table.session-info td {
 </table>
 </div>
 </div>
+             <div class="session-abstract">{{ _(session.abstract|markdown) }}</div>
           </div>
         </div>
 {% endwith %}
@@ -93,3 +94,25 @@ table.session-info td {
 {{ session_list(pending_sessions, _('Pending Proposals')) }}
 </main>
 {% endblock%}
+
+{% block scripts %}
+<script>
+$(function(){
+    var $setText = $('.session-abstract');
+    var cutFigure = 100;
+    var afterText = '...';
+
+    $setText.each(function(){
+        var textLength = $(this).text().length;
+        if(textLength > cutFigure){
+          var textTrim = $(this).text().substr(0,cutFigure);
+          $(this).text(textTrim + afterText);
+        }
+        else {
+          var text = $(this).text();
+          $(this).text(text);
+        }
+    });
+});
+</script>
+{% endblock %}


### PR DESCRIPTION
第一弾のPRで、第二弾以降も準備できている…といいつつ、時間がかかってしまいました(汗

![image](https://cloud.githubusercontent.com/assets/7414320/18034982/65ae3990-6d86-11e6-9db7-58bcd3e2b187.png)

* markdownは無効になっています(一旦Markdownを有効にして表示した後、文字列として抽出)
* このように、長い概要は…で省略するようになっています
  * 100文字で今のところ固定されていますが、英語/日本語で変えたほうがいいかもでしょうか？
![image](https://cloud.githubusercontent.com/assets/7414320/18034987/7acfc550-6d86-11e6-935a-df30cf240406.png)
