### PR TITLE
Select default slide and spoken languages

### DIFF
--- a/templates/session/form.tpl
+++ b/templates/session/form.tpl
@@ -87,7 +87,7 @@ You may use Markdown in this field{% endtrans %}">{% if session %}{{ session.get
             <div class="large-{{ left }} columns"><label>{% trans %}Spoken Language{% endtrans %}</label></div>
             <div class="large-{{ right }} columns">
               <p class="notice-small">{% trans %}Please select which language you will be speaking in.{% endtrans %}</p>
-              <select name="spoken_language">
+              <select name="spoken_language" id="select-spoken-language">
 {% set sel_spoken_language = session.get('spoken_language', 'en') if session else 'en' %}
 {% for l in languages %}
                 <option value="{{ l.value }}"{% if l.value == sel_spoken_language %} selected="selected"{% endif %}>{{ _(l.name) }}</option>
@@ -99,7 +99,7 @@ You may use Markdown in this field{% endtrans %}">{% if session %}{{ session.get
             <div class="large-{{ left }} columns"><label>{% trans %}Slide Language{% endtrans %}</label></div>
             <div class="large-{{ right }} columns">
               <p class="notice-small">{% trans %}Please select which language you will write your slides in.{% endtrans %}</p>
-              <select name="slide_language">
+              <select name="slide_language" id="select-slide-language">
 {% set sel_slide_language = session.get('slide_language', 'en') if session else 'en' %}
 {% for l in languages %}
                 <option value="{{ l.value }}"{% if l.value == sel_slide_language %} selected="selected"{% endif %}>{{ _(l.name) }}</option>

--- a/templates/session/form_scripts.tpl
+++ b/templates/session/form_scripts.tpl
@@ -13,6 +13,9 @@ $(function() {
   });
 
   $("#cfptabs").foundation("selectTab", "#panel-{{ lang }}");
+
+  $("#select-spoken-language").val("{{ lang }}");
+  $("#select-slide-language").val("{{ lang }}");
 })
 -->
 </script>


### PR DESCRIPTION
以前から「講演に使用される言語」と「スライド言語」は日本語ページ上でも英語がデフォルトになっていたみたいです。

### Before
![image](https://cloud.githubusercontent.com/assets/7414320/18224230/b002e7c0-7209-11e6-967b-933d427a846a.png)


### After
![image](https://cloud.githubusercontent.com/assets/7414320/18224233/ba6968d8-7209-11e6-8259-7472b15b1630.png)

