### PR TITLE
Refactoring

### DIFF
--- a/app.py
+++ b/app.py
@@ -28,8 +28,8 @@ CACHE_CONFERENCE_EXPIRES = 300
 CACHE_CONFERENCE_SESSIONS_EXPIRES = 300
 CACHE_SESSION_EXPIRES = 300
 LANGUAGES=[
- dict({'name': 'English', 'value': 'en'}),
- dict({'name': 'Japanese', 'value': 'ja'})
+    {'name': 'English', 'value': 'en'},
+    {'name': 'Japanese', 'value': 'ja'}
 ]
 
 class Config(object):

--- a/app.py
+++ b/app.py
@@ -42,8 +42,8 @@ class Config(object):
                 raise Exception( "missing section '" + section + "' in config file '" + file + "'" )
         if self.cfg.get('OCTAV').get('BASE_URI'):
             raise Exception(
-                'DEPRECATED: {"OCTAV":{"BASE_URI"}} in config.json is deprecated.\
- Please use {"OCTAV":{"endpoint"}} instead and remove {"OCTAV":{"BASE_URI"}}.'
+                'DEPRECATED: {"OCTAV":{"BASE_URI"}} in config.json is deprecated.'
+                ' Please use {"OCTAV":{"endpoint"}} instead and remove {"OCTAV":{"BASE_URI"}}.'
         )
 
     def section(self, name):

--- a/cache.py
+++ b/cache.py
@@ -51,7 +51,7 @@ class Memcached:
             if not servers:
                 raise Exception("servers missing in memcache settings")
             else:
-                server_settings = map( server_str, servers )
+                server_settings = [server_str(server) for server in  servers]
             self.client = memcache.Client(server_settings, debug)
 
     def set(self, key, val, expires=0):


### PR DESCRIPTION
理由は以下です
- dict({'key': 'value'})は{'key': 'value'}に等しいです
- 連続する文字列は(自動的に)結合されるので`\`で改行するよりインデントが揃って見やすくなります
- map()関数を使うより、リスト内包表記のほうが高速な場合が多く、また、Pythonicです